### PR TITLE
News policies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy as build
+FROM ubuntu:jammy AS build
 
 WORKDIR /build
 RUN apt update && apt install -y --no-install-recommends \
@@ -13,7 +13,7 @@ RUN git clone --branch 0.9.6 https://github.com/hoytech/strfry.git && cd strfry/
     && make clean \
     && make -j4
 
-FROM ubuntu:jammy as runner
+FROM ubuntu:jammy AS runner
 
 EXPOSE 7777
 
@@ -33,7 +33,7 @@ COPY ./strfry/config/strfry.conf /etc/strfry.conf
 RUN mkdir -p /app/strfry-db
 COPY ./strfry/plugins/ /app/plugins/
 
-RUN chmod +x /app/plugins/allowed_rules.js
+RUN chmod +x /app/plugins/policies.ts
 
 WORKDIR /app
 COPY --from=build /build/strfry/strfry strfry

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,6 @@
+services:
+  nosrelay:
+    build: .
+    ports:
+      - "7777:7777"
+

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,2 @@
+docker compose up --build --force-recreate
+

--- a/strfry/config/strfry.conf
+++ b/strfry/config/strfry.conf
@@ -60,7 +60,7 @@ relay {
 
     writePolicy {
         # If non-empty, path to an executable script that implements the writePolicy plugin logic
-        plugin = "/app/plugins/allowed_rules.js"
+        plugin = "/app/plugins/policies.ts"
 
         # Number of seconds to search backwards for lookback events when starting the writePolicy plugin (0 for no lookback)
         lookbackSeconds = 0

--- a/strfry/plugins/nos_policy.ts
+++ b/strfry/plugins/nos_policy.ts
@@ -1,0 +1,56 @@
+import type { Policy } from "https://gitlab.com/soapbox-pub/strfry-policies/-/raw/develop/mod.ts";
+
+const ALLOWED = {
+  pubs: {
+    b43cdcbe1b5a991e91636c1372abd046ff1d6b55a17722a2edf2d888aeaa3150: true, // NPD Media
+    "9561cd80e1207f685277c5c9716dde53499dd88c525947b1dde51374a81df0b9": true, // RevolutionZ Podcast
+    e526964aad10b63c24b3a582bfab4ef5937c559bfbfff3c18cb8d94909598575: true, // MuckRock Foundation
+    "36de364c2ea2a77f2ed42cd7f2528ef547b6ab0062e3645046188511fe106403": true, // ZNet
+    "99d0c998eaf2dbfaead9abf50919eba6495d8d615f0ded6b320948a4a4f8c478": true, // Patrick Boehler
+    "715dc06230d7c6aa62b044a8a764728ae6862eb100f1800ef91d5cc9f972dc55": true, // We Distribute
+    e70d313e00d3d77c3ca7324c082fce9bbdefbe1b88cf39d4e48078c1573808ed: true, // The Conversation
+    "0403c86a1bb4cfbc34c8a493fbd1f0d158d42dd06d03eaa3720882a066d3a378": true, // Global Sports Center
+    a78363acf392e7f6805d9d87654082dd83a02c6c565c804533e62b6f1da3f17d: true, // Alastair Thompson
+    b5ad453f5410107a61fde33b0bf7f61832e96b13f8fd85474355c34818a34091: true, // The 74
+  },
+  eventKinds: [
+    0, // Metadata
+    1, // Short Text Note
+    3, // Contacts
+    4, // Encrypted Direct Messages
+    5, // Event deletion
+    6, // Repost
+    7, // Reaction
+    1059, // Gift wrap messages
+    10000, // Mute list
+    10002, // Relay list metadata
+    30023, // Long-form Content
+  ],
+};
+
+// This overrides the allowed rules above
+const DISALLOWED = {
+  pubs: {},
+  startWithTexts: ["GM from ws"],
+};
+
+const nosPolicy: Policy<void> = (msg) => {
+  const event = msg.event;
+  const content = event.content;
+  let res = { id: event.id, action: "reject", msg: "blocked: not authorized" };
+
+  const isAllowedPub = ALLOWED.pubs.hasOwnProperty(event.pubkey);
+  const isAllowedEventKind = ALLOWED.eventKinds.includes(event.kind);
+  const isDisallowed =
+    DISALLOWED.pubs.hasOwnProperty(event.pubkey) ||
+    DISALLOWED.startWithTexts.some((text) => content.startsWith(text));
+
+  if (!isDisallowed && isAllowedEventKind && isAllowedPub) {
+    res.action = "accept";
+    res.msg = "";
+  }
+
+  return res;
+};
+
+export default nosPolicy;

--- a/strfry/plugins/nos_policy.ts
+++ b/strfry/plugins/nos_policy.ts
@@ -2,16 +2,16 @@ import type { Policy } from "https://gitlab.com/soapbox-pub/strfry-policies/-/ra
 
 const ALLOWED = {
   pubs: {
-    b43cdcbe1b5a991e91636c1372abd046ff1d6b55a17722a2edf2d888aeaa3150: true, // NPD Media
+    "b43cdcbe1b5a991e91636c1372abd046ff1d6b55a17722a2edf2d888aeaa3150": true, // NPD Media
     "9561cd80e1207f685277c5c9716dde53499dd88c525947b1dde51374a81df0b9": true, // RevolutionZ Podcast
-    e526964aad10b63c24b3a582bfab4ef5937c559bfbfff3c18cb8d94909598575: true, // MuckRock Foundation
+    "e526964aad10b63c24b3a582bfab4ef5937c559bfbfff3c18cb8d94909598575": true, // MuckRock Foundation
     "36de364c2ea2a77f2ed42cd7f2528ef547b6ab0062e3645046188511fe106403": true, // ZNet
     "99d0c998eaf2dbfaead9abf50919eba6495d8d615f0ded6b320948a4a4f8c478": true, // Patrick Boehler
     "715dc06230d7c6aa62b044a8a764728ae6862eb100f1800ef91d5cc9f972dc55": true, // We Distribute
-    e70d313e00d3d77c3ca7324c082fce9bbdefbe1b88cf39d4e48078c1573808ed: true, // The Conversation
+    "e70d313e00d3d77c3ca7324c082fce9bbdefbe1b88cf39d4e48078c1573808ed": true, // The Conversation
     "0403c86a1bb4cfbc34c8a493fbd1f0d158d42dd06d03eaa3720882a066d3a378": true, // Global Sports Center
-    a78363acf392e7f6805d9d87654082dd83a02c6c565c804533e62b6f1da3f17d: true, // Alastair Thompson
-    b5ad453f5410107a61fde33b0bf7f61832e96b13f8fd85474355c34818a34091: true, // The 74
+    "a78363acf392e7f6805d9d87654082dd83a02c6c565c804533e62b6f1da3f17d": true, // Alastair Thompson
+    "b5ad453f5410107a61fde33b0bf7f61832e96b13f8fd85474355c34818a34091": true, // The 74
   },
   eventKinds: [
     0, // Metadata

--- a/strfry/plugins/policies.ts
+++ b/strfry/plugins/policies.ts
@@ -11,7 +11,6 @@ import {
 import nosPolicy from "./nos_policy.ts";
 
 const localhost = "127.0.0.1";
-const eventsIp = await getEventsIp();
 
 // Policies that reject faster should be at the top. So synchronous policies should be at the top.
 const policies = [
@@ -19,21 +18,10 @@ const policies = [
   [hellthreadPolicy, { limit: 100 }],
   // Async policies
   [antiDuplicationPolicy, { ttl: 60000, minLength: 50 }],
-  [rateLimitPolicy, { whitelist: [localhost, eventsIp] }],
+  [rateLimitPolicy, { whitelist: [localhost] }],
 ];
 
 for await (const msg of readStdin()) {
   const result = await pipeline(msg, policies);
   writeStdout(result);
-}
-
-async function getEventsIp() {
-  const fallbackEventsIp = "174.138.53.241";
-
-  try {
-    const resolvedIps = await Deno.resolveDns("events.nos.social", "A");
-    return resolvedIps[0];
-  } catch (error) {
-    return fallbackEventsIp;
-  }
 }

--- a/strfry/plugins/policies.ts
+++ b/strfry/plugins/policies.ts
@@ -1,0 +1,39 @@
+#!/bin/sh
+//bin/true; exec deno run -A "$0" "$@"
+import {
+  antiDuplicationPolicy,
+  hellthreadPolicy,
+  pipeline,
+  rateLimitPolicy,
+  readStdin,
+  writeStdout,
+} from "https://gitlab.com/soapbox-pub/strfry-policies/-/raw/develop/mod.ts";
+import nosPolicy from "./nos_policy.ts";
+
+const localhost = "127.0.0.1";
+const eventsIp = await getEventsIp();
+
+// Policies that reject faster should be at the top. So synchronous policies should be at the top.
+const policies = [
+  nosPolicy,
+  [hellthreadPolicy, { limit: 100 }],
+  // Async policies
+  [antiDuplicationPolicy, { ttl: 60000, minLength: 50 }],
+  [rateLimitPolicy, { whitelist: [localhost, eventsIp] }],
+];
+
+for await (const msg of readStdin()) {
+  const result = await pipeline(msg, policies);
+  writeStdout(result);
+}
+
+async function getEventsIp() {
+  const fallbackEventsIp = "174.138.53.241";
+
+  try {
+    const resolvedIps = await Deno.resolveDns("events.nos.social", "A");
+    return resolvedIps[0];
+  } catch (error) {
+    return fallbackEventsIp;
+  }
+}


### PR DESCRIPTION
For https://github.com/planetary-social/nosrelay/issues/3

Similar policies to relay.nos.social but using the news allowed list, removed free pass to events.nos.social and use a different conditional logic