### PR TITLE
Bump event limits

### DIFF
--- a/strfry/config/strfry.conf
+++ b/strfry/config/strfry.conf
@@ -112,8 +112,13 @@ relay {
 }
 
 events {
-    # Maximum size of normalised JSON, in bytes
-    maxEventSize = 65536
+    # Maximum size of normalised JSON, in bytes One of the users we found was
+    # following 2546 users, and the JSON for that was 190k
+    # https://primal.net/p/npub1nlch0l8fj86x4ew2f5kxdn4q3vwmprkz0v7hsm9vcry62xee683qmqq7ay
+    # Explore the followers DB periodically to find the largest user, compare
+    # that with other services and check if the limits are still reasonable
+
+    maxEventSize = 262144
 
     # Events newer than this will be rejected
     rejectEventsNewerThanSeconds = 900
@@ -128,7 +133,7 @@ events {
     ephemeralEventsLifetimeSeconds = 300
 
     # Maximum number of tags allowed
-    maxNumTags = 2000
+    maxNumTags = 3000
 
     # Maximum size for tag values, in bytes
     maxTagValSize = 1024


### PR DESCRIPTION
While investigating differences of follower counts vs Primal I found that limits were too low and we are losing some events because of that.