### PR TITLE
Relay url suffix and connection manager

### DIFF
--- a/event_deleter/Cargo.lock
+++ b/event_deleter/Cargo.lock
@@ -737,6 +737,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
@@ -768,6 +769,7 @@ checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -789,6 +791,17 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1784,6 +1797,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "combine",
+ "futures",
  "futures-util",
  "itoa",
  "num-bigint",
@@ -1797,6 +1811,7 @@ dependencies = [
  "sha1_smol",
  "socket2",
  "tokio",
+ "tokio-retry",
  "tokio-rustls",
  "tokio-util",
  "url",
@@ -2360,6 +2375,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand",
+ "tokio",
 ]
 
 [[package]]

--- a/event_deleter/Cargo.toml
+++ b/event_deleter/Cargo.toml
@@ -10,7 +10,7 @@ config = { version = "0.14.0", features = ["yaml"] }
 env_logger = "0.11.5"
 nonzero_ext = "0.3.0"
 nostr-sdk = "0.35.0"
-redis = { version = "0.27.2", features = ["tls-rustls", "tls-rustls-webpki-roots", "tokio", "tokio-comp", "tokio-rustls", "tokio-rustls-comp"] }
+redis = { version = "0.27.2", features = ["connection-manager", "tls-rustls", "tls-rustls-webpki-roots", "tokio", "tokio-comp", "tokio-rustls", "tokio-rustls-comp"] }
 regex = "1.10.6"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
@@ -20,6 +20,7 @@ tokio-rustls = "0.26.0"
 tokio-util = { version = "0.7.12", features = ["rt"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+url = "2.5.2"
 
 [[bin]]
 name = "spam_cleaner"


### PR DESCRIPTION
I noticed that the task to record the last id processed was not scoped per relay so now I'm using a key that deals with this so instead of using `vanish_requests:deletion_subscriber:last_id` we use `vanish_requests:deletion_subscriber:last_id:example.com`.

Another problem was that the connection to update this value was closing after inactivity so now I'm using the connection manager which is ideal for this use case: https://github.com/redis-rs/redis-rs/issues/218