### PR TITLE
Retry redis failures

### DIFF
--- a/event_deleter/src/vanish_subscriber_task.rs
+++ b/event_deleter/src/vanish_subscriber_task.rs
@@ -75,11 +75,17 @@ pub trait RedisClientConnectionTrait: Send + Sync + 'static {
 #[async_trait]
 impl RedisClientConnectionTrait for RedisClientConnection {
     async fn get(&mut self, key: &str) -> Result<String, RedisError> {
-        self.con.get(key).await
+        match self.con.get(key).await {
+            Ok(value) => Ok(value),
+            Err(_) => self.con.get(key).await,
+        }
     }
 
     async fn set(&mut self, key: &str, value: String) -> Result<(), RedisError> {
-        self.con.set(key, value).await
+        match self.con.set(key, value.clone()).await {
+            Ok(()) => Ok(()),
+            Err(_) => self.con.set(key, value).await,
+        }
     }
 
     async fn xread_options(
@@ -88,7 +94,10 @@ impl RedisClientConnectionTrait for RedisClientConnection {
         ids: &[String],
         opts: &StreamReadOptions,
     ) -> Result<StreamReadReply, RedisError> {
-        self.con.xread_options(keys, ids, opts).await
+        match self.con.xread_options(keys, ids, opts).await {
+            Ok(reply) => Ok(reply),
+            Err(_) => self.con.xread_options(keys, ids, opts).await,
+        }
     }
 }
 


### PR DESCRIPTION
According to the [documentation](https://docs.rs/redis/latest/redis/aio/struct.ConnectionManager.html) for the connection manager:

> When a command sent to the server fails with an error that represents a “connection dropped” condition, that error will be passed on to the user, but it will trigger a reconnection in the background.

I changed the connection wrapper to try once more on errors so the reconnected connection is tried immediately.