### PR TITLE
Remember vanished pubkeys

### DIFF
--- a/strfry/plugins/broadcast_vanish_requests.ts
+++ b/strfry/plugins/broadcast_vanish_requests.ts
@@ -39,8 +39,8 @@ async function createBroadcastVanishRequests(
     if (cache.has(pubkey)) {
       return {
         id: event.id,
-        action: "shadowReject",
-        msg: "",
+        action: "reject",
+        msg: "invalid: vanished pubkey",
       } as OutputMessage;
     }
 

--- a/strfry/plugins/broadcast_vanish_requests.ts
+++ b/strfry/plugins/broadcast_vanish_requests.ts
@@ -3,14 +3,18 @@ import type {
   OutputMessage,
 } from "https://raw.githubusercontent.com/planetary-social/strfry-policies/refs/heads/nos-changes/mod.ts";
 import { log } from "https://raw.githubusercontent.com/planetary-social/strfry-policies/refs/heads/nos-changes/mod.ts";
+import { PubkeyCache } from "./pubkey_cache.ts";
 
 const REQUEST_TO_VANISH_KIND = 62;
 const VANISH_STREAM_KEY = "vanish_requests";
 
-function createBroadcastVanishRequests(
+const CACHE_MAX_SIZE = 1_000_000;
+
+async function createBroadcastVanishRequests(
   redis: any,
-  relay_url: string
-): Policy<void> {
+  relay_url: string,
+  vanishedPubkeyCache?: PubkeyCache
+): Promise<Policy<void>> {
   if (!redis) {
     throw new Error("REDIS_URL environment variable is not set.");
   }
@@ -19,8 +23,26 @@ function createBroadcastVanishRequests(
     throw new Error("RELAY_URL environment variable is not set.");
   }
 
+  let cache: PubkeyCache;
+  if (!vanishedPubkeyCache) {
+    cache = new PubkeyCache(redis, CACHE_MAX_SIZE);
+    await cache.initialize();
+  } else {
+    cache = vanishedPubkeyCache;
+  }
+
   return async (msg) => {
     const event = msg.event;
+    const pubkey = event.pubkey;
+
+    if (cache.has(pubkey)) {
+      return {
+        id: event.id,
+        action: "shadowReject",
+        msg: "",
+      } as OutputMessage;
+    }
+
     const accept: OutputMessage = {
       id: event.id,
       action: "accept",
@@ -41,6 +63,7 @@ function createBroadcastVanishRequests(
     }
 
     await broadcastVanishRequest(event, redis);
+    await cache.add(pubkey);
 
     return accept;
   };
@@ -54,7 +77,7 @@ async function broadcastVanishRequest(event: any, redis: any) {
   try {
     await redis.xadd(VANISH_STREAM_KEY, "*", event);
   } catch (error) {
-    log(`Failed to push request  ${event.id} to Redis Stream: ${error}`);
+    log(`Failed to push request ${event.id} to Redis Stream: ${error}`);
   }
 }
 

--- a/strfry/plugins/broadcast_vanish_requests.ts
+++ b/strfry/plugins/broadcast_vanish_requests.ts
@@ -5,6 +5,7 @@ import type {
 import { log } from "https://raw.githubusercontent.com/planetary-social/strfry-policies/refs/heads/nos-changes/mod.ts";
 import { PubkeyCache } from "./pubkey_cache.ts";
 
+// https://github.com/vitorpamplona/nips/blob/right-to-vanish/62.md
 const REQUEST_TO_VANISH_KIND = 62;
 const VANISH_STREAM_KEY = "vanish_requests";
 

--- a/strfry/plugins/policies.ts
+++ b/strfry/plugins/policies.ts
@@ -25,7 +25,10 @@ const redis_connect_options = parseURL(redis_url);
 const redis = await connect(redis_connect_options);
 
 const relay_url = Deno.env.get("RELAY_URL");
-const broadcastVanishRequests = createBroadcastVanishRequests(redis, relay_url);
+const broadcastVanishRequests = await createBroadcastVanishRequests(
+  redis,
+  relay_url
+);
 
 // Policies that reject faster should be at the top. So synchronous policies should be at the top.
 const policies = [

--- a/strfry/plugins/pubkey_cache.ts
+++ b/strfry/plugins/pubkey_cache.ts
@@ -1,8 +1,24 @@
-// In process cache to avoid accepting pubkeys that were already removed from
-// the relay. We store CACHE_MAX_SIZE items in redis so restarts don't lose the
-// cache. This assumes that after CACHE_MAX_SIZE items are processed, the
+// In-process cache to avoid accepting pubkeys that were already removed from
+// the relay. We store `CACHE_MAX_SIZE` items in Redis so restarts don't lose
+// the cache. This assumes that after `CACHE_MAX_SIZE` items are processed, the
 // oldest ones are no longer relevant and probably not used anymore in the
-// network to avoid to have an infinite cache.
+// network, to avoid having an infinite cache.
+//
+// The `Set` is used for quick O(1) in-process lookups when we need to read from
+// the cache. This ensures that there is very little lag because these lookups
+// are extremely fast, much faster than Redis itself. The `Queue` allows us to
+// remove the oldest entries when we exceed the maximum cache size to control
+// memory usage. Both the `Set` and `Queue` are in-process data structures because
+// Strfry blocks until it receives a response from a plugin, so write operations
+// need to be as optimized as possible.
+//
+// While Redis is great, it's still too slow to be called on each write
+// operation; it's asynchronous and remote compared to synchronous local
+// queries, which are orders of magnitude faster. Therefore, the main use for
+// Redis in this case is to persist the cache across restarts. By storing the
+// cache in Redis, we ensure that the application retains important state
+// information even after it restarts, without compromising the performance of
+// relay write operations.
 class PubkeyCache {
   private maxSize: number;
   private queue: string[] = [];

--- a/strfry/plugins/pubkey_cache.ts
+++ b/strfry/plugins/pubkey_cache.ts
@@ -1,0 +1,59 @@
+// In process cache to avoid accepting pubkeys that were already removed from
+// the relay. We store CACHE_MAX_SIZE items in redis so restarts don't lose the
+// cache. This assumes that after CACHE_MAX_SIZE items are processed, the
+// oldest ones are no longer relevant and probably not used anymore in the
+// network to avoid to have an infinite cache.
+class PubkeyCache {
+  private maxSize: number;
+  private queue: string[] = [];
+  private set: Set<string> = new Set();
+  private redis: any;
+  public static readonly ZSET_KEY = "processed_pubkeys_zset";
+
+  constructor(redis: any, maxSize: number) {
+    this.redis = redis;
+    this.maxSize = maxSize;
+  }
+
+  async initialize(): Promise<void> {
+    const pubkeys = await this.redis.zrevrange(
+      PubkeyCache.ZSET_KEY,
+      0,
+      this.maxSize - 1
+    );
+
+    for (const pubkey of pubkeys) {
+      this.queue.push(pubkey);
+      this.set.add(pubkey);
+    }
+
+    const totalCount = await this.redis.zcard(PubkeyCache.ZSET_KEY);
+    if (totalCount > this.maxSize) {
+      await this.redis.zremrangebyrank(PubkeyCache.ZSET_KEY, this.maxSize, -1);
+    }
+  }
+
+  has(pubkey: string): boolean {
+    return this.set.has(pubkey);
+  }
+
+  async add(pubkey: string): Promise<void> {
+    if (!this.set.has(pubkey)) {
+      this.queue.push(pubkey);
+      this.set.add(pubkey);
+
+      const now = Date.now();
+      await this.redis.zadd(PubkeyCache.ZSET_KEY, now, pubkey);
+
+      if (this.queue.length > this.maxSize) {
+        const oldestPubkey = this.queue.shift();
+        if (oldestPubkey !== undefined) {
+          this.set.delete(oldestPubkey);
+          await this.redis.zrem(PubkeyCache.ZSET_KEY, oldestPubkey);
+        }
+      }
+    }
+  }
+}
+
+export { PubkeyCache };

--- a/strfry/plugins/tests/broadcast_vanish_requests.test.ts
+++ b/strfry/plugins/tests/broadcast_vanish_requests.test.ts
@@ -50,6 +50,10 @@ class RedisMock {
   }
 }
 
+async function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 Deno.test({
   name: "pushes a vanish request and then shadowRejects on duplicate pubkey",
   fn: async () => {
@@ -86,6 +90,9 @@ Deno.test({
     const result2 = await broadcastVanishRequests(msg);
     assertEquals(result2.action, "shadowReject");
     assertEquals(redisMock.called, false);
+
+    // Some time to let the logs flush
+    await wait(100);
   },
   sanitizeResources: false,
 });
@@ -125,6 +132,9 @@ Deno.test({
 
     const result2 = await broadcastVanishRequests(msg);
     assertEquals(result2.action, "shadowReject");
+
+    // Some time to let the logs flush
+    await wait(100);
     assertEquals(redisMock.called, false);
   },
   sanitizeResources: false,
@@ -160,6 +170,10 @@ Deno.test({
 
     const result2 = await broadcastVanishRequests(msg);
     assertEquals(result2.action, "accept");
+    assertEquals(redisMock.called, false);
+
+    // Some time to let the logs flush
+    await wait(100);
     assertEquals(redisMock.called, false);
   },
   sanitizeResources: false,
@@ -199,6 +213,10 @@ Deno.test({
     const result2 = await broadcastVanishRequests(msg);
     assertEquals(result2.action, "accept");
     assertEquals(redisMock.called, false);
+
+    // Some time to let the logs flush
+    await wait(100);
+    assertEquals(redisMock.called, false);
   },
   sanitizeResources: false,
 });
@@ -234,6 +252,10 @@ Deno.test({
     // Since the pubkey is pre-loaded, it should shadowReject
     const result = await broadcastVanishRequests(msg);
     assertEquals(result.action, "shadowReject");
+    assertEquals(redisMock.called, false);
+
+    // Some time to let the logs flush
+    await wait(100);
     assertEquals(redisMock.called, false);
   },
   sanitizeResources: false,

--- a/strfry/plugins/tests/broadcast_vanish_requests.test.ts
+++ b/strfry/plugins/tests/broadcast_vanish_requests.test.ts
@@ -1,27 +1,64 @@
 import { assertEquals } from "https://deno.land/std@0.181.0/testing/asserts.ts";
 import { buildEvent, buildInputMessage } from "./test.ts";
 import { createBroadcastVanishRequests } from "../broadcast_vanish_requests.ts";
+import { PubkeyCache } from "../pubkey_cache.ts";
 import type { Event } from "https://raw.githubusercontent.com/planetary-social/strfry-policies/refs/heads/nos-changes/mod.ts";
 
 class RedisMock {
   called: boolean = false;
+  zset: Map<string, number> = new Map();
 
   async xadd(streamKey: string, id: string, event: Event): Promise<void> {
     this.called = true;
   }
-}
 
-async function wait(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  async zrevrange(key: string, start: number, stop: number): Promise<string[]> {
+    const entries = Array.from(this.zset.entries());
+    entries.sort((a, b) => b[1] - a[1]);
+    const sliced = entries.slice(start, stop + 1);
+    return sliced.map(([pubkey, _score]) => pubkey);
+  }
+
+  async zcard(key: string): Promise<number> {
+    return this.zset.size;
+  }
+
+  async zremrangebyrank(
+    key: string,
+    start: number,
+    stop: number
+  ): Promise<void> {
+    const entries = Array.from(this.zset.entries());
+    entries.sort((a, b) => a[1] - b[1]);
+    const toRemove = entries.slice(start, stop + 1);
+    for (const [pubkey, _score] of toRemove) {
+      this.zset.delete(pubkey);
+    }
+  }
+
+  async zscore(key: string, member: string): Promise<number | null> {
+    const score = this.zset.get(member);
+    return score !== undefined ? score : null;
+  }
+
+  async zadd(key: string, score: number, member: string): Promise<void> {
+    this.zset.set(member, score);
+  }
+
+  async zrem(key: string, member: string): Promise<void> {
+    this.zset.delete(member);
+  }
 }
 
 Deno.test({
-  name: "pushes a vanish request with global relay filter",
+  name: "pushes a vanish request and then shadowRejects on duplicate pubkey",
   fn: async () => {
+    const pubkey = "pubkey123";
     const msg = buildInputMessage({
       sourceType: "IP4",
       sourceInfo: "1.1.1.1",
       event: buildEvent({
+        pubkey: pubkey,
         kind: 62,
         tags: [
           ["relay", "ALL_RELAYS"],
@@ -31,27 +68,37 @@ Deno.test({
     });
 
     const redisMock = new RedisMock();
-    const broadcastVanishRequests = createBroadcastVanishRequests(
+    const pubkeyCache = new PubkeyCache(redisMock, 1000);
+    await pubkeyCache.initialize();
+
+    const broadcastVanishRequests = await createBroadcastVanishRequests(
       redisMock,
-      "example.com"
+      "example.com",
+      pubkeyCache
     );
 
-    assertEquals((await broadcastVanishRequests(msg)).action, "accept");
+    const result1 = await broadcastVanishRequests(msg);
+    assertEquals(result1.action, "accept");
     assertEquals(redisMock.called, true);
 
-    // Some time to let the logs flush
-    await wait(100);
+    redisMock.called = false;
+
+    const result2 = await broadcastVanishRequests(msg);
+    assertEquals(result2.action, "shadowReject");
+    assertEquals(redisMock.called, false);
   },
   sanitizeResources: false,
 });
 
 Deno.test({
-  name: "pushes a vanish request with specific relay filter",
+  name: "pushes a vanish request with specific relay filter and then shadowRejects on duplicate pubkey",
   fn: async () => {
+    const pubkey = "pubkey456";
     const msg = buildInputMessage({
       sourceType: "IP4",
       sourceInfo: "1.1.1.1",
       event: buildEvent({
+        pubkey: pubkey,
         kind: 62,
         tags: [
           ["relay", "example.com"],
@@ -61,16 +108,24 @@ Deno.test({
     });
 
     const redisMock = new RedisMock();
-    const broadcastVanishRequests = createBroadcastVanishRequests(
+    const pubkeyCache = new PubkeyCache(redisMock, 1000);
+    await pubkeyCache.initialize();
+
+    const broadcastVanishRequests = await createBroadcastVanishRequests(
       redisMock,
-      "example.com"
+      "example.com",
+      pubkeyCache
     );
 
-    assertEquals((await broadcastVanishRequests(msg)).action, "accept");
+    const result1 = await broadcastVanishRequests(msg);
+    assertEquals(result1.action, "accept");
     assertEquals(redisMock.called, true);
 
-    // Some time to let the logs flush
-    await wait(100);
+    redisMock.called = false;
+
+    const result2 = await broadcastVanishRequests(msg);
+    assertEquals(result2.action, "shadowReject");
+    assertEquals(redisMock.called, false);
   },
   sanitizeResources: false,
 });
@@ -78,26 +133,34 @@ Deno.test({
 Deno.test({
   name: "doesn't push a vanish request with no matching relay filter",
   fn: async () => {
+    const pubkey = "pubkey789";
     const msg = buildInputMessage({
       sourceType: "IP4",
       sourceInfo: "1.1.1.1",
       event: buildEvent({
+        pubkey: pubkey,
         kind: 62,
         tags: [["relay", "notexample.com"]],
       }),
     });
 
     const redisMock = new RedisMock();
-    const broadcastVanishRequests = createBroadcastVanishRequests(
+    const pubkeyCache = new PubkeyCache(redisMock, 1000);
+    await pubkeyCache.initialize();
+
+    const broadcastVanishRequests = await createBroadcastVanishRequests(
       redisMock,
-      "example.com"
+      "example.com",
+      pubkeyCache
     );
 
-    assertEquals((await broadcastVanishRequests(msg)).action, "accept");
+    const result = await broadcastVanishRequests(msg);
+    assertEquals(result.action, "accept");
     assertEquals(redisMock.called, false);
 
-    // Some time to let the logs flush
-    await wait(100);
+    const result2 = await broadcastVanishRequests(msg);
+    assertEquals(result2.action, "accept");
+    assertEquals(redisMock.called, false);
   },
   sanitizeResources: false,
 });
@@ -105,10 +168,12 @@ Deno.test({
 Deno.test({
   name: "doesn't push when kind is not a vanish request",
   fn: async () => {
+    const pubkey = "pubkey101112";
     const msg = buildInputMessage({
       sourceType: "IP4",
       sourceInfo: "1.1.1.1",
       event: buildEvent({
+        pubkey: pubkey,
         kind: 1,
         tags: [
           ["relay", "ALL_RELAYS"],
@@ -118,15 +183,58 @@ Deno.test({
     });
 
     const redisMock = new RedisMock();
-    const broadcastVanishRequests = createBroadcastVanishRequests(
+    const pubkeyCache = new PubkeyCache(redisMock, 1000);
+    await pubkeyCache.initialize();
+
+    const broadcastVanishRequests = await createBroadcastVanishRequests(
       redisMock,
-      "example.com"
+      "example.com",
+      pubkeyCache
     );
-    assertEquals((await broadcastVanishRequests(msg)).action, "accept");
+
+    const result = await broadcastVanishRequests(msg);
+    assertEquals(result.action, "accept");
     assertEquals(redisMock.called, false);
 
-    // Some time to let the logs flush
-    await wait(100);
+    const result2 = await broadcastVanishRequests(msg);
+    assertEquals(result2.action, "accept");
+    assertEquals(redisMock.called, false);
+  },
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "shadowRejects when pubkey is pre-loaded in cache",
+  fn: async () => {
+    const pubkey = "vanishedPubkey";
+    const redisMock = new RedisMock();
+
+    const now = Date.now();
+    await redisMock.zadd(PubkeyCache.ZSET_KEY, now, pubkey);
+
+    const pubkeyCache = new PubkeyCache(redisMock, 1000);
+    await pubkeyCache.initialize();
+
+    const msg = buildInputMessage({
+      sourceType: "IP4",
+      sourceInfo: "1.1.1.1",
+      event: buildEvent({
+        pubkey: pubkey,
+        kind: 62,
+        tags: [["relay", "ALL_RELAYS"]],
+      }),
+    });
+
+    const broadcastVanishRequests = await createBroadcastVanishRequests(
+      redisMock,
+      "example.com",
+      pubkeyCache
+    );
+
+    // Since the pubkey is pre-loaded, it should shadowReject
+    const result = await broadcastVanishRequests(msg);
+    assertEquals(result.action, "shadowReject");
+    assertEquals(redisMock.called, false);
   },
   sanitizeResources: false,
 });

--- a/strfry/plugins/tests/broadcast_vanish_requests.test.ts
+++ b/strfry/plugins/tests/broadcast_vanish_requests.test.ts
@@ -55,7 +55,7 @@ async function wait(ms: number): Promise<void> {
 }
 
 Deno.test({
-  name: "pushes a vanish request and then shadowRejects on duplicate pubkey",
+  name: "pushes a vanish request and then rejects on duplicate pubkey",
   fn: async () => {
     const pubkey = "pubkey123";
     const msg = buildInputMessage({
@@ -88,7 +88,7 @@ Deno.test({
     redisMock.called = false;
 
     const result2 = await broadcastVanishRequests(msg);
-    assertEquals(result2.action, "shadowReject");
+    assertEquals(result2.action, "reject");
     assertEquals(redisMock.called, false);
 
     // Some time to let the logs flush
@@ -98,7 +98,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "pushes a vanish request with specific relay filter and then shadowRejects on duplicate pubkey",
+  name: "pushes a vanish request with specific relay filter and then rejects on duplicate pubkey",
   fn: async () => {
     const pubkey = "pubkey456";
     const msg = buildInputMessage({
@@ -131,7 +131,7 @@ Deno.test({
     redisMock.called = false;
 
     const result2 = await broadcastVanishRequests(msg);
-    assertEquals(result2.action, "shadowReject");
+    assertEquals(result2.action, "reject");
 
     // Some time to let the logs flush
     await wait(100);
@@ -222,7 +222,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "shadowRejects when pubkey is pre-loaded in cache",
+  name: "rejects when pubkey is pre-loaded in cache",
   fn: async () => {
     const pubkey = "vanishedPubkey";
     const redisMock = new RedisMock();
@@ -249,9 +249,9 @@ Deno.test({
       pubkeyCache
     );
 
-    // Since the pubkey is pre-loaded, it should shadowReject
+    // Since the pubkey is pre-loaded, it should reject it
     const result = await broadcastVanishRequests(msg);
-    assertEquals(result.action, "shadowReject");
+    assertEquals(result.action, "reject");
     assertEquals(redisMock.called, false);
 
     // Some time to let the logs flush


### PR DESCRIPTION
Maps to https://github.com/planetary-social/nosrelay/issues/20.

[NIP-62](https://github.com/vitorpamplona/nips/blob/right-to-vanish/62.md) specifies:
> Relays MUST ensure the deleted events cannot be re-broadcasted into the relay.

To address this, this PR introduces an in-process cache, initialized through a Redis ordered set, that tracks the last million deleted pubkeys. Once a pubkey is removed from our relay, events from that pubkey will be rejected if it’s still present in the cache. The Redis ordered set guarantees that the cache persists across restarts. We assume that one million entries are sufficient and that it is highly unlikely for a deleted pubkey to reappear after one million deletions.

Additionally, NIP-62 also states:
> Relays SHOULD delete all [NIP-59](https://github.com/vitorpamplona/nips/blob/right-to-vanish/59.md) Gift Wraps that p-tagged the .pubkey if their service URL is tagged in the event, deleting all DMs to the pubkey.

This PR ensures the removal of any gift wraps sent to the deleted pubkey.