### PR TITLE
Fix healthcheck, add deploy script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,7 +133,7 @@ RUN chmod +x /app/push_vanish_request.ts
 
 COPY ./start.sh start.sh
 
-HEALTHCHECK --interval=1h --timeout=5s --start-period=10s \
-  CMD nak req -l 1 localhost:7777 | jq -e '.created_at as $ts | ($ts > (now | floor - 86400))' || exit 1
+HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
+  CMD curl -fSsI http://localhost:7777/ || exit 1
 
 CMD ./start.sh

--- a/scripts/tag_as_stable.sh
+++ b/scripts/tag_as_stable.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Pull specified image sha and tag it as stable to trigger the deploy process
+
+SOURCE=$1
+if [ -z "$SOURCE" ]; then
+  echo "Usage: $0 <image_sha>"
+  exit 1
+fi
+
+docker pull --platform linux/amd64 ghcr.io/planetary-social/nosrelay@sha256:$SOURCE && \
+docker tag ghcr.io/planetary-social/nosrelay@sha256:$SOURCE ghcr.io/planetary-social/nosrelay:stable && \
+docker push ghcr.io/planetary-social/nosrelay:stable


### PR DESCRIPTION
The strfry container was stuck in "starting" state, causing Traefik to filter it out and route all traffic to the redirect-service instead. Fixed by simplifying the healthcheck to a basic HEAD request with proper timeouts, allowing Traefik to correctly detect when the service is ready. 

Already deployed and verified working on news.nos.social, I created the PR anyways for tracing and review. Also added scripts to manage image tagging for deployments.